### PR TITLE
[Role Customer] Xem lịch sử sách đã hủy

### DIFF
--- a/librarymanagement/src/main/java/org/librarymanagement/controller/api/BorrowRequestController.java
+++ b/librarymanagement/src/main/java/org/librarymanagement/controller/api/BorrowRequestController.java
@@ -73,4 +73,28 @@ public class BorrowRequestController {
                 books.getTotalPages()
         ));
     }
+
+    @GetMapping("/cancelled")
+    public ResponseEntity<PageResponse<BorrowFlatResponse>> getCancelledBorrowRequest(Pageable pageable) {
+
+        User user = currentUserService.getCurrentUser();
+
+        Page<BorrowFlatResponse> books = borrowRequestService.getCancelledBorrowRequests(user, pageable);
+
+        String successMessage = messageSource.getMessage(
+                "user.borrowBooks.cancelledBook",
+                null,
+                LocaleContextHolder.getLocale()
+        );
+
+        return ResponseEntity.ok(new PageResponse<>(
+                successMessage,
+                HttpStatus.OK.value(),
+                books.getContent(),
+                books.getNumber(),
+                books.getSize(),
+                books.getTotalElements(),
+                books.getTotalPages()
+        ));
+    }
 }

--- a/librarymanagement/src/main/java/org/librarymanagement/entity/BorrowRequest.java
+++ b/librarymanagement/src/main/java/org/librarymanagement/entity/BorrowRequest.java
@@ -31,6 +31,9 @@ public class BorrowRequest {
     @Column(nullable = false)
     private Integer status;
 
+    @Column(name = "cancel_reason")
+    private String cancelReason;
+
     @Column(name = "day_confirmed")
     private LocalDateTime dayConfirmed;
 

--- a/librarymanagement/src/main/java/org/librarymanagement/service/BorrowRequestService.java
+++ b/librarymanagement/src/main/java/org/librarymanagement/service/BorrowRequestService.java
@@ -1,7 +1,6 @@
 package org.librarymanagement.service;
 
 import org.librarymanagement.dto.response.BorrowFlatResponse;
-import org.librarymanagement.dto.response.PageResponse;
 import org.librarymanagement.dto.response.ResponseObject;
 import org.librarymanagement.entity.User;
 import org.springframework.data.domain.Page;
@@ -10,4 +9,5 @@ import org.springframework.data.domain.Pageable;
 public interface BorrowRequestService {
     public ResponseObject getPendingBorrowRequests(User user);
     public Page<BorrowFlatResponse> getReturnedBorrowRequests(User user, Pageable pageable);
+    public Page<BorrowFlatResponse> getCancelledBorrowRequests(User user, Pageable pageable);
 }

--- a/librarymanagement/src/main/java/org/librarymanagement/service/impl/BRCleanupServiceImpl.java
+++ b/librarymanagement/src/main/java/org/librarymanagement/service/impl/BRCleanupServiceImpl.java
@@ -94,6 +94,7 @@ public class BRCleanupServiceImpl implements BRCleanupService {
         overdueBorrows.forEach(br ->{
             handleSendMail(br,EmailType.RESERVED_OVERDUE_BORROW_REQUEST);
             br.setStatus((BRStatusConstant.CANCELED.getValue()));
+            br.setCancelReason("Vì đã quá thời gian giữ sách là 3 ngày nên yêu cầu mượn bị hủy");
 
             br.getBorrowRequestItems().forEach(brItem -> {
                 brItem.setStatus((BRItemStatusConstant.CANCELLED));

--- a/librarymanagement/src/main/resources/message.properties
+++ b/librarymanagement/src/main/resources/message.properties
@@ -159,6 +159,8 @@ user.borrowBooks.pending = Danh sách sách đã mượn nhưng chưa lấy
 user.borrowBooks.noPendingRequests=Không có danh sách sách đã mượn nhưng chưa lấy
 user.borrowBooks.returnedBook = Danh sách sách đã trả
 user.borrowBooks.noReturnedBook = Không có danh sách sách đã trả
+user.borrowBooks.cancelledBook = Danh sách sách đã hủy
+user.borrowBooks.noCancelledBook = Không có danh sách sách đã hủy
 
 book.borrowDate=Ngày mượn
 book.returnDate=Ngày trả


### PR DESCRIPTION
## ✅ Checklist tự review pull trước khi ready để trainer review (Java Spring Boot)
- [x] Sử dụng **thụt lề 4 spaces** đồng nhất ở tất cả các files `.java`, `.xml`, `.html`, `.properties`, v.v. (cấu hình lại IntelliJ/VSCode nếu chưa setup).
- [x] Cuối mỗi file cần có **end line** (`\n`) để tránh lỗi đỏ khi diff trên Git.
- [x] Mỗi dòng nếu quá dài thì cần xuống dòng (tối đa **100 ký tự/dòng**, cài đặt wrap line trong IDE nếu cần).
- [x] `.gitignore` các file nhạy cảm (VD: `application-secret.properties`, `.env`, `/target/`, `.log`, `.class`, ...).
- [x] Tham khảo và tuân theo Java Coding Convention:
  - https://google.github.io/styleguide/javaguide.html
  - hoặc https://www.oracle.com/java/technologies/javase/codeconventions-contents.html
- [x] Kiểm tra mỗi pull request **chỉ có 1 commit**, nếu nhiều hơn hãy dùng `git rebase -i` để gộp commit.
- [x] Cài đặt `Checkstyle`, `PMD`, hoặc plugin Java linter tương ứng trong IDE để kiểm tra coding convention. Format lại trước khi gửi pull.
- [x] Nếu làm việc nhóm, mỗi pull cần **ít nhất 1 APPROVED** từ thành viên khác trong nhóm.

---
## Related Tickets
- [#92037](https://edu-redmine.sun-asterisk.vn/issues/92037)

## WHAT (optional)
- Xem danh sách sách đã bị hủy kèm theo lý do hủy

## HOW
- Thêm hàm getCancelledBorrowRequests(User user, Pageable pageable) trong BorrowRequestServiceImpl
- Lấy tất cả BorrowRequest của người dùng có trạng thái CANCELED
- Duyệt qua từng BorrowRequest để lấy danh sách BorrowRequestItem
- Chuyển đổi dữ liệu sang BorrowFlatResponse, trong đó có thêm trường cancelReason để hiển thị lý do hủy
- Trả về danh sách phân trang (Page<BorrowFlatResponse>) các sách đã bị hủy 

## WHY (optional)
- 

## Evidence (Screenshot or Video)
<img width="1917" height="997" alt="image" src="https://github.com/user-attachments/assets/432a921a-fd8f-4447-84d6-7ac2cf7c56e2" />
<img width="1919" height="1003" alt="image" src="https://github.com/user-attachments/assets/365bc735-1071-41c8-9fa6-5081edfbb98f" />
